### PR TITLE
[latex] forced linebreaks for fenced code using

### DIFF
--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -34,9 +34,10 @@
 \urlstyle{same}  % don't use monospace font for urls
 \usepackage{color}
 \usepackage{fancyvrb}
+\usepackage{fvextra}
 \newcommand{\VerbBar}{|}
 \newcommand{\VERB}{\Verb[commandchars=\\\{\}]}
-\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,commandchars=\\\{\}}
 % Add ',fontsize=\small' for more characters per line
 \newenvironment{Shaded}{}{}
 \newcommand{\AlertTok}[1]{\textcolor[rgb]{1.00,0.00,0.00}{\textbf{#1}}}


### PR DESCRIPTION
Per suggestion in #4302. I hope this is the correct place to make these innocent edits.
The patch makes sure that long lines of fenced code are broken (LaTeX). The solution requires the additional package [fvextra](https://ctan.org/pkg/fvextra) which nicely collaborates with `fancyvrb`.